### PR TITLE
#25 削除用要素をクリックするとその行を削除する

### DIFF
--- a/src/components/TodoList.vue
+++ b/src/components/TodoList.vue
@@ -19,7 +19,7 @@
             @keyup.enter="doneEdit"
           />
         </td>
-        <td><div>delete</div></td>
+        <td><div @click="deleteTask(task.index)">delete</div></td>
       </tr>
     </table>
   </div>
@@ -37,6 +37,9 @@ export default Vue.extend({
   methods: {
     doneEdit() {
       this.tasks.push({ completed: false, task: "" });
+    },
+    deleteTask(index: number) {
+      this.tasks.splice(index, 1);
     },
   },
 });

--- a/tests/unit/todolist.spec.ts
+++ b/tests/unit/todolist.spec.ts
@@ -41,3 +41,23 @@ describe("新しいタスクを追加する", () => {
     expect(wrapper.vm.$data.tasks[1].task).toBe("");
   });
 });
+
+describe("タスクを削除する", () => {
+  const wrapper = shallowMount(TodoList);
+  const deleteTarget = wrapper.findAll("tr").at(0);
+  const form = deleteTarget.findAll("td").at(1).find("input[type='text']");
+
+  it("削除要素をクリックすると一行消える", async () => {
+    // テストのためdataを2行にする
+    await form.setValue("doing task");
+    await form.trigger("keyup.enter");
+
+    // 行削除
+    const deleteButton = deleteTarget.findAll("td").at(2).find("div");
+    await deleteButton.trigger("click");
+
+    // 削除後の検証
+    expect(wrapper.vm.$data.tasks.length).toBe(1);
+    expect(wrapper.vm.$data.tasks[0].task).toBe("");
+  });
+});


### PR DESCRIPTION
## 概要

表題の通りです。削除は`v-for`のindex要素を`Array.prototype.splice`の`start`に設定することで対応しました。
一行削除のためこれで良いと考えています。

https://developer.mozilla.org/ja/docs/Web/JavaScript/Reference/Global_Objects/Array/splice

