### PR TITLE
#15 一括でチェックボックスをトグル可能にする

### DIFF
--- a/src/components/TodoList.vue
+++ b/src/components/TodoList.vue
@@ -1,26 +1,40 @@
 <template>
   <div id="todo-list">
     <table>
-      <tr v-for="task in tasks" :key="task.index">
-        <td>
-          <input
-            type="checkbox"
-            name="check"
-            id="check"
-            v-model="task.completed"
-          />
-        </td>
-        <td>
-          <input
-            type="text"
-            name="form"
-            id="form"
-            v-model="task.task"
-            @keyup.enter="doneEdit"
-          />
-        </td>
-        <td><div @click="deleteTask(task.index)">delete</div></td>
-      </tr>
+      <thead>
+        <tr>
+          <td>
+            <input
+              type="checkbox"
+              name="toggle-all"
+              id="toggle-all"
+              @click="toggleAll"
+            />
+          </td>
+        </tr>
+      </thead>
+      <tbody>
+        <tr v-for="task in tasks" :key="task.index">
+          <td>
+            <input
+              type="checkbox"
+              name="check"
+              id="check"
+              v-model="task.completed"
+            />
+          </td>
+          <td>
+            <input
+              type="text"
+              name="form"
+              id="form"
+              v-model="task.task"
+              @keyup.enter="doneEdit"
+            />
+          </td>
+          <td><div @click="deleteTask(task.index)">delete</div></td>
+        </tr>
+      </tbody>
     </table>
   </div>
 </template>
@@ -40,6 +54,11 @@ export default Vue.extend({
     },
     deleteTask(index: number) {
       this.tasks.splice(index, 1);
+    },
+    toggleAll() {
+      for (const param of this.tasks) {
+        param.completed = !param.completed;
+      }
     },
   },
 });

--- a/tests/unit/todolist.spec.ts
+++ b/tests/unit/todolist.spec.ts
@@ -4,6 +4,10 @@ import TodoList from "@/components/TodoList.vue";
 describe("初期状態", () => {
   const wrapper = shallowMount(TodoList);
   const body = wrapper.find("tbody");
+
+  it("一括切り替え用ボタン：チェックOFF", () => {
+    expect(wrapper.vm.$data.tasks[0].completed).toBe(false);
+  });
   it("一行表示される", () => {
     expect(body.findAll("tr").length).toBe(1);
   });
@@ -37,7 +41,7 @@ describe("新しいタスクを追加する", () => {
   });
   it("Enterキー押下で空行追加される", async () => {
     await form.trigger("keyup.enter");
-    expect(wrapper.findAll("tr").length).toBe(2);
+    expect(wrapper.find("tbody").findAll("tr").length).toBe(2);
     expect(wrapper.vm.$data.tasks[1].completed).toBe(false);
     expect(wrapper.vm.$data.tasks[1].task).toBe("");
   });
@@ -60,5 +64,26 @@ describe("タスクを削除する", () => {
     // 削除後の検証
     expect(wrapper.vm.$data.tasks.length).toBe(1);
     expect(wrapper.vm.$data.tasks[0].task).toBe("");
+  });
+});
+
+describe("一括ON/OFF切り替えチェックボックス", () => {
+  const wrapper = shallowMount(TodoList);
+  const toggleAll = wrapper.find("thead").find("input[type='checkbox']");
+  const body = wrapper.find("tbody").findAll("td");
+
+  it("タスクが一つ以上あるとき、クリックでチェックONに切り替えられる", async () => {
+    // テストのためdataを2行にする
+    await body.at(1).find("input[type='text']").setValue("doing task");
+    await body.at(1).find("input[type='text']").trigger("keyup.enter");
+    // クリック
+    await toggleAll.trigger("click");
+    expect(wrapper.vm.$data.tasks[0].completed).toBe(true);
+    expect(wrapper.vm.$data.tasks[1].completed).toBe(true);
+
+    // クリック
+    await toggleAll.trigger("click");
+    expect(wrapper.vm.$data.tasks[0].completed).toBe(false);
+    expect(wrapper.vm.$data.tasks[1].completed).toBe(false);
   });
 });

--- a/tests/unit/todolist.spec.ts
+++ b/tests/unit/todolist.spec.ts
@@ -3,30 +3,31 @@ import TodoList from "@/components/TodoList.vue";
 
 describe("初期状態", () => {
   const wrapper = shallowMount(TodoList);
+  const body = wrapper.find("tbody");
   it("一行表示される", () => {
-    expect(wrapper.findAll("tr").length).toBe(1);
+    expect(body.findAll("tr").length).toBe(1);
   });
   it("左端はチェックボックス表示 チェック：OFF", () => {
-    const left = wrapper.findAll("td").at(0);
+    const left = body.findAll("td").at(0);
     const content = left.find("input[type='checkbox']");
     expect(content.exists()).toBe(true);
     expect(wrapper.vm.$data.tasks[0].completed).toBe(false);
   });
   it("中央は空のフォーム", () => {
-    const central = wrapper.findAll("td").at(1);
+    const central = body.findAll("td").at(1);
     const content = central.find("input[type='text']");
     expect(content.exists()).toBe(true);
     expect(wrapper.vm.$data.tasks[0].task).toBe("");
   });
   it("右端は削除ボタン", () => {
-    const right = wrapper.findAll("td").at(2);
+    const right = body.findAll("td").at(2);
     expect(right.find("div").exists()).toBe(true);
   });
 });
 
 describe("新しいタスクを追加する", () => {
   const wrapper = shallowMount(TodoList);
-  const firstRow = wrapper.findAll("tr").at(0);
+  const firstRow = wrapper.find("tbody").findAll("tr").at(0);
   const form = firstRow.findAll("td").at(1).find("input[type='text']");
   beforeEach(async () => {
     await form.setValue("new task");
@@ -44,7 +45,7 @@ describe("新しいタスクを追加する", () => {
 
 describe("タスクを削除する", () => {
   const wrapper = shallowMount(TodoList);
-  const deleteTarget = wrapper.findAll("tr").at(0);
+  const deleteTarget = wrapper.find("tbody").findAll("tr").at(0);
   const form = deleteTarget.findAll("td").at(1).find("input[type='text']");
 
   it("削除要素をクリックすると一行消える", async () => {


### PR DESCRIPTION
## 概要

表題の通りです。`<thead>`に一括でON/OFFを切り替えるためのチェックボックスを追加しました。

## 気になる点

チェックボックスの`@checked`イベントをキャッチしてトグルするようにしたのですが、`@changed`をキャッチするべきという記事もチラホラ見かけます。

ただ、Vue Devtoolsを見るとチェックボックス操作で`@checked`が発火しているので`@changed`ではないのかなと思います。この辺使い分けをどうすると良いのかが気になっています。他のFWやUIライブラリの実装を確認するといいのかな？